### PR TITLE
README.md:add info about using egcc on BSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ cp /tmp/xstr/src/* deps/xstr/
     make
     (optionally) make install
     
+**Note**: BSD users may need to install the *gcc* package and change
+the `configure` command:
+
+    `CC=egcc ../configure`
+
 ### Build example.c
 
 From the build directory:


### PR DESCRIPTION
"egcc" isn't a typo. Not sure I can explain. I'm not very familiar with BSD yet. I saw it's use on another project, and tested it on xstr.

ping #5 
