### PR TITLE
xstr.pc.in:remove ununsed include path

### DIFF
--- a/xstr.pc.in
+++ b/xstr.pc.in
@@ -9,4 +9,4 @@ Version: @VERSION@
 Requires:
 Libs.private: @LIBS@
 Libs: -L${libdir} -lxstr
-Cflags: -I${includedir} -I${includedir}/xstr
+Cflags: -I${includedir}


### PR DESCRIPTION
The header doesn't get installed to the xstr/ directory.

Right now, I get this output:

```
andy@oceanus:~/src/xstr$ pkg-config --cflags-only-I  xstr
-I/usr/local/include -I/usr/local/include/xstr
```

This patch fixes that.