### PR TITLE
put example into top_builddir, add it to the "clean" target

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,3 +14,16 @@ example_SOURCES = example.c
 example_DEPENDENCIES = libxstr.la
 example_LDFLAGS = -all-static -L@top_builddir@/src/.libs
 example_LDADD = -lxstr
+
+example$(EXEEXT): $(example_OBJECTS) $(example_DEPENDENCIES)
+	$(LINK) $(example_LDFLAGS) $(example_OBJECTS) $(example_LDADD)
+	file=example;	\
+	if test -f $$file; then	\
+		mv $$file $(top_builddir)/$$file;	\
+	fi
+
+clean-local:
+	file=$(top_builddir)/example; \
+	if test -f $$file; then \
+		rm $$file; \
+	fi


### PR DESCRIPTION
This also will remove the example binary when "make clean" is run.

fixes part of #8